### PR TITLE
Feature: Google OAuth2 로그인 및 JWT 인증 처리 로직 도입

### DIFF
--- a/src/main/java/com/toy/devtilor/devtilor/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/toy/devtilor/devtilor/auth/jwt/JwtProvider.java
@@ -1,0 +1,23 @@
+package com.toy.devtilor.devtilor.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    public String createToken(String username, String role) {
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("role", role)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3600000)) // 1시간
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/toy/devtilor/devtilor/auth/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/toy/devtilor/devtilor/auth/oauth/CustomOAuth2User.java
@@ -1,0 +1,45 @@
+package com.toy.devtilor.devtilor.auth.oauth;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuth2Response oAuth2Response;
+    private final String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return role;
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of();
+    }
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return OAuth2User.super.getAttribute(name);
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2Response.getName();
+    }
+
+    public String getUsername() {
+        return oAuth2Response.getProvider() + ":" + oAuth2Response.getProviderId();
+    }
+}

--- a/src/main/java/com/toy/devtilor/devtilor/auth/oauth/GoogleResponse.java
+++ b/src/main/java/com/toy/devtilor/devtilor/auth/oauth/GoogleResponse.java
@@ -1,0 +1,29 @@
+package com.toy.devtilor.devtilor.auth.oauth;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GoogleResponse implements OAuth2Response{
+    private final Map<String, Object> attribute;
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/toy/devtilor/devtilor/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/toy/devtilor/devtilor/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,77 @@
+package com.toy.devtilor.devtilor.auth.oauth;
+
+import com.toy.devtilor.devtilor.auth.jwt.JwtProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final JwtProvider jwtProvider;
+
+    private static final String FRONTEND_REDIRECT_URL = "http://localhost:3000/oauth-success";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication)
+            throws IOException, ServletException {
+
+        if (!(authentication instanceof OAuth2AuthenticationToken oauthToken)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid authentication type");
+            return;
+        }
+
+        OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+                oauthToken.getAuthorizedClientRegistrationId(),
+                oauthToken.getName()
+        );
+
+        if (client == null) {
+            log.error("OAuth2 Client not found for user: {}", oauthToken.getName());
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "OAuth2 Client not found");
+            return;
+        }
+
+        // ✅ Access Token from Google
+        String googleAccessToken = client.getAccessToken().getTokenValue();
+        log.info("🔑 Google Access Token: {}", googleAccessToken);
+
+        // ✅ 사용자 정보 가져오기
+        String email = oauthToken.getPrincipal().getAttribute("email");
+        String role = oauthToken.getAuthorities().stream()
+                .findFirst()
+                .map(Object::toString)
+                .orElse("ROLE_USER");
+
+        if (email == null || email.isBlank()) {
+            log.warn("Email not found in OAuth2User attributes");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Email not found");
+            return;
+        }
+
+        // ✅ JWT 발급
+        String jwt = jwtProvider.createToken(email, role);
+
+        // ✅ 응답 헤더 전달
+        response.setHeader("Authorization", "Bearer " + jwt);
+        response.setHeader("Google-Access-Token", googleAccessToken);
+
+        // ✅ 리디렉션
+        response.sendRedirect(FRONTEND_REDIRECT_URL);
+    }
+}

--- a/src/main/java/com/toy/devtilor/devtilor/auth/oauth/OAuth2Response.java
+++ b/src/main/java/com/toy/devtilor/devtilor/auth/oauth/OAuth2Response.java
@@ -1,0 +1,12 @@
+package com.toy.devtilor.devtilor.auth.oauth;
+
+public interface OAuth2Response {
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+    String getEmail();
+    //사용자 실명 (설정한 이름)
+    String getName();
+}

--- a/src/main/java/com/toy/devtilor/devtilor/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/toy/devtilor/devtilor/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package com.toy.devtilor.devtilor.auth.service;
+
+import com.toy.devtilor.devtilor.auth.oauth.CustomOAuth2User;
+import com.toy.devtilor.devtilor.auth.oauth.GoogleResponse;
+import com.toy.devtilor.devtilor.auth.oauth.OAuth2Response;
+import com.toy.devtilor.devtilor.domain.user.entity.User;
+import com.toy.devtilor.devtilor.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User.getAttributes());
+
+        OAuth2Response oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+
+        String username = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        User existData = userRepository.findByUsername(username);
+
+        String role = "ROLE_USER";
+        if (existData == null) {
+            User newUser = User.builder()
+                    .username(username)
+                    .email(oAuth2Response.getEmail())
+                    .role(role)
+                    .build();
+
+            userRepository.save(newUser);
+        }
+        else {
+            existData = User.builder()
+                    .username(username)
+                    .email(oAuth2Response.getEmail())
+                    .role(role)
+                    .build();
+            // 최신 이메일 정보 동기화
+            userRepository.save(existData);
+        }
+        return new CustomOAuth2User(oAuth2Response, role);
+    }
+}

--- a/src/main/java/com/toy/devtilor/devtilor/config/SecurityConfig.java
+++ b/src/main/java/com/toy/devtilor/devtilor/config/SecurityConfig.java
@@ -1,21 +1,37 @@
 package com.toy.devtilor.devtilor.config;
 
+import com.toy.devtilor.devtilor.auth.oauth.OAuth2LoginSuccessHandler;
+import com.toy.devtilor.devtilor.auth.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
-                .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                )
-                .build();
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.httpBasic(AbstractHttpConfigurer::disable);
+        http.oauth2Login((oauth2) -> oauth2
+                .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                        .userService(customOAuth2UserService))
+                .successHandler(oAuth2LoginSuccessHandler)
+        );
+
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                .anyRequest().authenticated());
+
+        return http.build();
     }
 }

--- a/src/main/java/com/toy/devtilor/devtilor/domain/user/entity/User.java
+++ b/src/main/java/com/toy/devtilor/devtilor/domain/user/entity/User.java
@@ -1,0 +1,28 @@
+package com.toy.devtilor.devtilor.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    private String username;
+    private String email;
+
+    private String role;
+}

--- a/src/main/java/com/toy/devtilor/devtilor/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/toy/devtilor/devtilor/domain/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.toy.devtilor.devtilor.domain.user.repository;
+
+import com.toy.devtilor.devtilor.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUsername(String username);
+}


### PR DESCRIPTION
## 개요

구글 OAuth2 로그인을 통해 사용자를 인증하고, 로그인 성공 시 자체 JWT를 발급해 프론트엔드로 전달하는 인증 흐름을 구축했습니다.
OAuth 응답 파싱, 사용자 정보 저장, JWT 발급까지의 전 과정을 서버에서 처리합니다.

---

##  주요 변경 사항
### 1.  **Spring Security 설정 (`SecurityConfig`)**

* `formLogin`, `httpBasic` 비활성화
* `oauth2Login` 기반 설정 적용
* 사용자 정보를 처리하는 `CustomOAuth2UserService` 등록

### 2.  **OAuth2 사용자 정보 처리**

* `OAuth2Response`, `GoogleResponse`: 구글 응답 구조 파싱
* `CustomOAuth2User`: `OAuth2User` 인터페이스 커스텀 구현
* `CustomOAuth2UserService`: 신규 사용자 저장 및 기존 사용자 조회 처리

### 3.  **로그인 성공 핸들러** 
  * `OAuth2LoginSuccessHandler`에서:
  * Google AccessToken 추출
  * 사용자 email 및 role 기반 JWT 발급
  * 응답 헤더에 JWT 포함 후 프론트엔드로 리다이렉트

#### 4.  **JWT 발급 유틸**
* `JwtProvider`: HS256 기반 JWT 생성 유틸리티 구현

### 5.  **User 도메인 구성**
* `User`, `UserRepository`:
  * 사용자 정보(username/email/role) 저장 및 조회
  * provider + providerId 조합으로 중복 방지



